### PR TITLE
Remove Filter overload with parameterless error selector

### DIFF
--- a/samples/MvcValidation/Controller/AsyncPersonController.cs
+++ b/samples/MvcValidation/Controller/AsyncPersonController.cs
@@ -13,7 +13,7 @@ namespace MvcValidation.Controller {
                 .ToResult<PersonPostApiModel, PersonPostApiError>()
                 .Multiple(
                     x => x.Filter(y => y.Age > 10,
-                        () => new PersonPostApiError {Message = "Age needs to be more than 10", Model = model}),
+                        _ => new PersonPostApiError {Message = "Age needs to be more than 10", Model = model}),
                     x => x.Flatten(y => ValidateName(y.FirstName),
                         s => new PersonPostApiError {Message = s, Model = model}),
                     x => x.Flatten(y => ValidateName(y.LastName),
@@ -58,8 +58,8 @@ namespace MvcValidation.Controller {
         private static Result<string, string> ValidateName(string name) {
             return name.ToResult<string, string>()
                 .IsErrorWhen(string.IsNullOrWhiteSpace, () => "Name cannot be empty.")
-                .Filter(s => s.All(char.IsLetter), () => "Name can only contain letters.")
-                .Filter(s => char.IsUpper(s[0]), () => "Name must start with capital letter.");
+                .Filter(s => s.All(char.IsLetter), _ => "Name can only contain letters.")
+                .Filter(s => char.IsUpper(s[0]), _ => "Name must start with capital letter.");
         }
     }
 }

--- a/samples/MvcValidation/Controller/PersonController.cs
+++ b/samples/MvcValidation/Controller/PersonController.cs
@@ -13,7 +13,7 @@ namespace MvcValidation.Controller {
                 .ToResult<PersonPostApiModel, PersonPostApiError>()
                 .Multiple(
                     x => x.Filter(y => y.Age > 10,
-                        () => new PersonPostApiError {Message = "Age needs to be more than 10", Model = model}),
+                        _ => new PersonPostApiError {Message = "Age needs to be more than 10", Model = model}),
                     x => x.Flatten(y => ValidateName(y.FirstName),
                         s => new PersonPostApiError {Message = s, Model = model}),
                     x => x.Flatten(y => ValidateName(y.LastName),
@@ -52,8 +52,8 @@ namespace MvcValidation.Controller {
         private static Result<string, string> ValidateName(string name) {
             return name.ToResult<string, string>()
                 .IsErrorWhen(string.IsNullOrWhiteSpace, () => "Name cannot be empty.")
-                .Filter(s => s.All(char.IsLetter), () => "Name can only contain letters.")
-                .Filter(s => char.IsUpper(s[0]), () => "Name must start with capital letter.");
+                .Filter(s => s.All(char.IsLetter), _ => "Name can only contain letters.")
+                .Filter(s => char.IsUpper(s[0]), _ => "Name must start with capital letter.");
         }
     }
 }

--- a/samples/ReadFileAsync/Program.cs
+++ b/samples/ReadFileAsync/Program.cs
@@ -10,7 +10,7 @@ namespace ReadFileAsync {
         private static int Main(string[] args) {
             return args[0]
                 .ToResult<string, int>()
-                .Filter(File.Exists, () => 1)
+                .Filter(File.Exists, _ => 1)
                 .DoWithError(x => Console.WriteLine("File does not exist."))
                 .FlatMap(VerifyFilextension, i => {
                     Console.WriteLine("Invalid file extension.");

--- a/src/Lemonad.ErrorHandling/Extensions/Internal/TaskResultFunctions.cs
+++ b/src/Lemonad.ErrorHandling/Extensions/Internal/TaskResultFunctions.cs
@@ -36,16 +36,10 @@ namespace Lemonad.ErrorHandling.Extensions.Internal {
             Action<TError> action) => (await source.ConfigureAwait(false)).DoWithError(action);
 
         [Pure]
-        internal static async Task<Result<T, TError>> Filter<T, TError>(Task<Result<T, TError>> source,
-            Func<T, bool> predicate,
-            Func<TError> errorSelector) =>
-            (await source.ConfigureAwait(false)).Filter(predicate, errorSelector);
-
-        [Pure]
-        internal static async Task<Result<T, TError>> Filter<T, TError>(
+        internal static async Task<Result<T, TResult>> Filter<T, TError, TResult>(
             this Task<Result<T, TError>> source,
             Func<T, bool> predicate,
-            Func<Maybe<T>, TError> errorSelector) =>
+            Func<Maybe<T>, TResult> errorSelector) =>
             (await source.ConfigureAwait(false)).Filter(predicate, errorSelector);
 
         [Pure]

--- a/src/Lemonad.ErrorHandling/Outcome.cs
+++ b/src/Lemonad.ErrorHandling/Outcome.cs
@@ -29,12 +29,8 @@ namespace Lemonad.ErrorHandling {
         public static implicit operator Outcome<T, TError>(TError error) =>
             new Outcome<T, TError>(Task.FromResult(ResultExtensions.Error<T, TError>(error)));
 
-        /// <inheritdoc cref="Result{T,TError}.Filter(System.Func{T,bool},System.Func{TError})" />
-        public Outcome<T, TError> Filter(Func<T, bool> predicate, Func<TError> errorSelector) =>
-            TaskResultFunctions.Filter(Result, predicate, errorSelector);
-
-        /// <inheritdoc cref="Result{T,TError}.Filter(System.Func{T,bool},System.Func{Maybe{T},TError})" />
-        public Outcome<T, TError> Filter(Func<T, bool> predicate, Func<Maybe<T>, TError> errorSelector) =>
+        /// <inheritdoc cref="Result{T,TError}.Filter{TResult}" />
+        public Outcome<T, TResult> Filter<TResult>(Func<T, bool> predicate, Func<Maybe<T>, TResult> errorSelector) =>
             Result.Filter(predicate, errorSelector);
 
         /// <inheritdoc cref="Result{T,TError}.HasError" />

--- a/src/Lemonad.ErrorHandling/Result.cs
+++ b/src/Lemonad.ErrorHandling/Result.cs
@@ -233,33 +233,20 @@ namespace Lemonad.ErrorHandling {
         ///     A function to test <typeparamref name="T" />.
         /// </param>
         /// <param name="errorSelector">
-        ///     Is exectued when the predicate fails.
-        /// </param>
-        [Pure]
-        public Result<T, TError> Filter(Func<T, bool> predicate, Func<TError> errorSelector) =>
-            Filter(predicate, _ => errorSelector());
-
-        /// <summary>
-        ///     Filters the <typeparamref name="T" /> if <typeparamref name="T" /> is the active type.
-        /// </summary>
-        /// <param name="predicate">
-        ///     A function to test <typeparamref name="T" />.
-        /// </param>
-        /// <param name="errorSelector">
         ///     Is exectued when the predicate fails. The in parameter is a <see cref="Maybe{T}" /> whose <typeparamref name="T" />
         ///     has been checked to not be null.
         ///     But the <see cref="Maybe{T}" /> could still be unsafe and should be used with care.
         /// </param>
         [Pure]
-        public Result<T, TError> Filter(Func<T, bool> predicate, Func<Maybe<T>, TError> errorSelector) {
-            if (HasError) return ResultExtensions.Error<T, TError>(Error);
+        public Result<T, TResult> Filter<TResult>(Func<T, bool> predicate, Func<Maybe<T>, TResult> errorSelector) {
+            if (HasError) return ResultExtensions.Error<T, TResult>(errorSelector(Maybe<T>.None));
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
             if (predicate(Value))
-                return ResultExtensions.Ok<T, TError>(Value);
+                return ResultExtensions.Ok<T, TResult>(Value);
             return errorSelector == null
                 ? throw new ArgumentNullException(nameof(errorSelector))
-                : ResultExtensions.Error<T, TError>(errorSelector(Value.Some().IsNoneWhenNull()));
+                : ResultExtensions.Error<T, TResult>(errorSelector(Value.Some().IsNoneWhenNull()));
         }
 
         /// <summary>

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/FilterTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/FilterTests.cs
@@ -11,7 +11,7 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             var result = Division(10, 0).Filter(d => {
                 predicateExectued = true;
                 return d == 2;
-            }, () => {
+            }, _ => {
                 errorSelectorExectued = true;
                 return "Bad";
             });
@@ -57,7 +57,7 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             var result = Division(10, 2).Filter(d => {
                 predicateExectued = true;
                 return false;
-            }, () => {
+            }, _ => {
                 errorSelectorExectued = true;
                 return "Bad";
             });
@@ -100,7 +100,7 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             var result = Division(10, 2).Filter(d => {
                 predicateExectued = true;
                 return true;
-            }, () => {
+            }, _ => {
                 errorSelectorExectued = true;
                 return "Bad";
             });

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FilterTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FilterTests.cs
@@ -12,7 +12,7 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var filter = TaskResultFunctions.Filter(AssertionUtilities.DivisionAsync(10, 0), d => {
                 predicateExectued = true;
                 return d == 2;
-            }, () => {
+            }, _ => {
                 errorSelectorExectued = true;
                 return "Bad";
             });
@@ -36,7 +36,7 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var filter = TaskResultFunctions.Filter(AssertionUtilities.DivisionAsync(10, 2), d => {
                 predicateExectued = true;
                 return false;
-            }, () => {
+            }, _ => {
                 errorSelectorExectued = true;
                 return "Bad";
             });
@@ -58,7 +58,7 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var filter = TaskResultFunctions.Filter(AssertionUtilities.DivisionAsync(10, 2), d => {
                 predicateExectued = true;
                 return true;
-            }, () => {
+            }, _ => {
                 errorSelectorExectued = true;
                 return "Bad";
             });


### PR DESCRIPTION
You can just skip using the in parameter if it's not needed.