### PR TITLE
Maybe now uses a Result<T, TError> under the hood

### DIFF
--- a/src/Lemonad.ErrorHandling/EquailtyFunctions.cs
+++ b/src/Lemonad.ErrorHandling/EquailtyFunctions.cs
@@ -4,7 +4,9 @@ using System.Diagnostics.Contracts;
 namespace Lemonad.ErrorHandling {
     internal static class EquailtyFunctions {
         [Pure]
-        internal static bool IsNull<TElement>(TElement element) =>
-            EqualityComparer<TElement>.Default.Equals(element, default) && element == null;
+        internal static bool IsNull<TElement>(TElement element) {
+            var x = EqualityComparer<TElement>.Default.Equals(element, default) && element == null;
+            return x;
+        }
     }
 }

--- a/src/Lemonad.ErrorHandling/Extensions/MaybeExtensions.cs
+++ b/src/Lemonad.ErrorHandling/Extensions/MaybeExtensions.cs
@@ -89,7 +89,8 @@ namespace Lemonad.ErrorHandling.Extensions {
         ///     A <see cref="Maybe{T}" /> who will have no value.
         /// </returns>
         [Pure]
-        public static Maybe<TSource> None<TSource>(this TSource item) => new Maybe<TSource>(item, false);
+        public static Maybe<TSource> None<TSource>(this TSource item) =>
+            new Maybe<TSource>(item.ToResult(x => false, Unit.Selector));
 
         /// <summary>
         ///     Works like <see cref="None{TSource}(TSource)" /> but with an <paramref name="predicate" /> to test the element.
@@ -105,9 +106,10 @@ namespace Lemonad.ErrorHandling.Extensions {
         /// </typeparam>
         [Pure]
         public static Maybe<TSource> None<TSource>(this TSource source, Func<TSource, bool> predicate) =>
-            predicate != null
-                ? Some(source).Filter(x => !predicate(x))
-                : throw new ArgumentNullException(nameof(predicate));
+            new Maybe<TSource>(source.ToResult(x => {
+                if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+                return predicate(x) == false;
+            }, Unit.Selector));
 
         /// <summary>
         ///     Converts an <see cref="IEnumerable{T}" /> of <see cref="Maybe{T}" /> into an <see cref="IEnumerable{T}" /> of
@@ -141,7 +143,8 @@ namespace Lemonad.ErrorHandling.Extensions {
         ///     A <see cref="Maybe{T}" /> whose value will be <paramref name="item" />.
         /// </returns>
         [Pure]
-        public static Maybe<TSource> Some<TSource>(this TSource item) => new Maybe<TSource>(item, true);
+        public static Maybe<TSource> Some<TSource>(this TSource item) =>
+            new Maybe<TSource>(item.ToResult(x => true, Unit.Selector));
 
         /// <summary>
         ///     Works like <see cref="Some{TSource}(TSource)" /> but with an <paramref name="predicate" /> to test the element.
@@ -156,10 +159,11 @@ namespace Lemonad.ErrorHandling.Extensions {
         ///     The type of the <paramref name="source" />.
         /// </typeparam>
         [Pure]
-        public static Maybe<TSource> Some<TSource>(this TSource source, Func<TSource, bool> predicate) =>
-            predicate != null
-                ? Some(source).Filter(predicate)
-                : throw new ArgumentNullException(nameof(predicate));
+        public static Maybe<TSource> Some<TSource>(this TSource source, Func<TSource, bool> predicate) {
+            if (predicate != null)
+                return Some(source).Filter(predicate);
+            throw new ArgumentNullException(nameof(predicate));
+        }
 
         /// <summary>
         ///     Converts an <see cref="Nullable{T}" /> to an <see cref="Maybe{T}" />.

--- a/src/Lemonad.ErrorHandling/Maybe.cs
+++ b/src/Lemonad.ErrorHandling/Maybe.cs
@@ -24,7 +24,7 @@ namespace Lemonad.ErrorHandling {
         ///     Treat <typeparamref name="T" /> as enumerable with 0-1 elements in.
         ///     This is handy when combining <see cref="Result{T,TError}" /> with LINQ's API.
         /// </summary>
-        public IEnumerable<T> AsEnumerable => Yield(this);
+        public IEnumerable<T> AsEnumerable => _result.AsEnumerable;
 
         internal T Value { get; }
 
@@ -35,13 +35,7 @@ namespace Lemonad.ErrorHandling {
         }
 
         /// <inheritdoc />
-        public bool Equals(Maybe<T> other) {
-            if (!HasValue && !other.HasValue)
-                return true;
-            if (HasValue && other.HasValue)
-                return EqualityComparer<T>.Default.Equals(Value, other.Value);
-            return false;
-        }
+        public bool Equals(Maybe<T> other) => other._result.Equals(_result);
 
         public static implicit operator Maybe<T>(T item) => item.Some();
 
@@ -52,14 +46,10 @@ namespace Lemonad.ErrorHandling {
         public static bool operator !=(Maybe<T> left, Maybe<T> right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public override int GetHashCode() => !HasValue ? 0 : (Value == null ? 1 : Value.GetHashCode());
+        public override int GetHashCode() => _result.GetHashCode();
 
         /// <inheritdoc />
-        public int CompareTo(Maybe<T> other) {
-            if (HasValue && !other.HasValue) return 1;
-            if (!HasValue && other.HasValue) return -1;
-            return Comparer<T>.Default.Compare(Value, other.Value);
-        }
+        public int CompareTo(Maybe<T> other) => other._result.CompareTo(other._result);
 
         public static bool operator <(Maybe<T> left, Maybe<T> right) => left.CompareTo(right) < 0;
 
@@ -73,10 +63,6 @@ namespace Lemonad.ErrorHandling {
         public override string ToString() =>
             $"{(HasValue ? "Some" : "None")} ==> {typeof(Maybe<T>).ToHumanString()}{StringFunctions.PrettyTypeString(Value)}";
 
-        private static IEnumerable<T> Yield(Maybe<T> maybe) {
-            if (maybe.HasValue)
-                yield return maybe.Value;
-        }
 
         /// <summary>
         ///     Evaluates the <see cref="Maybe{T}" />.

--- a/src/Lemonad.ErrorHandling/Unit.cs
+++ b/src/Lemonad.ErrorHandling/Unit.cs
@@ -7,6 +7,7 @@ namespace Lemonad.ErrorHandling {
     /// </summary>
     [Serializable]
     public readonly struct Unit : IEquatable<Unit>, IComparable<Unit> {
+        public static readonly Func<Unit> Selector = () => Default;
         public static readonly Unit Default = new Unit();
 
         [Pure]

--- a/test/Lemonad.ErrorHandling.Test/Maybe.Tests/IsNoneWhenNullTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Maybe.Tests/IsNoneWhenNullTests.cs
@@ -34,7 +34,8 @@ namespace Lemonad.ErrorHandling.Test.Maybe.Tests {
 
         [Fact]
         public void Maybe_Overload__With_Some_Empty_String() {
-            var maybe = "".Some().IsNoneWhenNull();
+            var some = "".Some();
+            var maybe = some.IsNoneWhenNull();
             Assert.True(maybe.HasValue, "Maybe should have a value, since the string is not null.");
             Assert.Equal(string.Empty, maybe.Value);
         }

--- a/test/Lemonad.ErrorHandling.Test/Maybe.Tests/MatchTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Maybe.Tests/MatchTests.cs
@@ -72,9 +72,11 @@ namespace Lemonad.ErrorHandling.Test.Maybe.Tests {
         }
 
         [Fact]
-        public void Null_SomeSelector__Throws() {
+        public void Null_SomeSelector__Does_Not_Throw() {
+            // Since there Hasvalue is false it should not be invoked.
             Func<string, int> someSelector = null;
-            Assert.Throws<ArgumentNullException>(() => "hello".Some(s => false).Match(someSelector, () => 2));
+            var exception = Record.Exception(() => "hello".Some(s => false).Match(someSelector, () => 2));
+            Assert.Null(exception);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Maybe.Tests/ToStringTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Maybe.Tests/ToStringTests.cs
@@ -2,19 +2,23 @@
 using Xunit;
 
 namespace Lemonad.ErrorHandling.Test.Maybe.Tests {
+    /// <summary>
+    ///     Maybe is based on <see cref="Result{T,TError}" /> and Result currently does not support showing the value of
+    ///     TError. instead it will be default keyword.
+    /// </summary>
     public class ToStringTests {
         [Fact]
         public void None_Maybe_Char_With__Expects_String_To_have__Doble_Quotes() {
             var maybe = 'x'.None();
             Assert.False(maybe.HasValue, "Maybe Should not have value.");
-            Assert.Equal("None ==> Maybe<Char>(\'x\')", maybe.ToString());
+            Assert.Equal($@"None ==> Maybe<Char>('{default(char)}')", maybe.ToString());
         }
 
         [Fact]
         public void None_Maybe_String_With_Content__Expects_String_To_have__Doble_Quotes() {
             var maybe = "hello".None();
             Assert.False(maybe.HasValue, "Maybe Should not have value.");
-            Assert.Equal("None ==> Maybe<String>(\"hello\")", maybe.ToString());
+            Assert.Equal($@"None ==> Maybe<String>(null)", maybe.ToString());
         }
 
         [Fact]
@@ -29,7 +33,7 @@ namespace Lemonad.ErrorHandling.Test.Maybe.Tests {
         public void None_Maybe_String_Without_Content__Expects_String_To_have__Doble_Quotes() {
             var maybe = string.Empty.None();
             Assert.False(maybe.HasValue, "Maybe Should not have value.");
-            Assert.Equal("None ==> Maybe<String>(\"\")", maybe.ToString());
+            Assert.Equal($@"None ==> Maybe<String>(null)", maybe.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
Since `Maybe<T>` works exactly the same as `Result<T, Unit>` it is possible to use `Result<T, Unit>`' under the hood to reduce code getting repeated.