### PR TITLE
Add either property

### DIFF
--- a/src/Lemonad.ErrorHandling/AsyncResult.cs
+++ b/src/Lemonad.ErrorHandling/AsyncResult.cs
@@ -62,11 +62,8 @@ namespace Lemonad.ErrorHandling {
         public AsyncResult<T, TError> Filter(Func<T, Task<bool>> predicate, Func<Maybe<T>, TError> errorSelector) =>
             TaskResultFunctions.Filter(TaskResult, predicate, errorSelector);
 
-        /// <inheritdoc cref="Result{T,TError}.HasError" />
-        public Task<bool> HasError => TaskResultFunctions.HasError(TaskResult);
 
-        /// <inheritdoc cref="Result{T,TError}.HasValue" />
-        public Task<bool> HasValue => TaskResultFunctions.HasValue(TaskResult);
+        public Task<Either<T, TError>> Either => TaskResultFunctions.Either(TaskResult);
 
         /// <inheritdoc cref="Result{T,TError}.Multiple" />
         public AsyncResult<T, IReadOnlyList<TError>> Multiple(

--- a/src/Lemonad.ErrorHandling/Either.cs
+++ b/src/Lemonad.ErrorHandling/Either.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace Lemonad.ErrorHandling {
+    /// <summary>
+    /// Contains either <typeparamref name="T"/> or <typeparamref name="TError"/>.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The value type.
+    /// </typeparam>
+    /// <typeparam name="TError">
+    /// The error type.
+    /// </typeparam>
+    public readonly struct Either<T, TError> {
+        /// <summary>
+        ///     Is true if there's a <typeparamref name="T" /> in the current state of the <see cref="Result{T,TError}" />.
+        /// </summary>
+        public bool HasValue { get; }
+
+        /// <summary>
+        ///     Is true if there's a <typeparamref name="TError" /> in the current state of the <see cref="Result{T,TError}" />.
+        /// </summary>
+        public bool HasError { get; }
+
+        public TError Error { get; }
+        public T Value { get; }
+
+        public Either(in T value, in TError error, bool hasError, bool hasValue) {
+            if (hasError == hasValue)
+                throw new ArgumentException(
+                    $"Can never have the same value {nameof(hasError)} ({hasError}) and {nameof(hasValue)} ({hasValue})."
+                );
+
+            HasValue = hasValue;
+            HasError = hasError;
+            Value = value;
+            Error = error;
+        }
+    }
+}

--- a/src/Lemonad.ErrorHandling/Either.cs
+++ b/src/Lemonad.ErrorHandling/Either.cs
@@ -21,7 +21,38 @@ namespace Lemonad.ErrorHandling {
         /// </summary>
         public bool HasError { get; }
 
+        /// <summary>
+        /// The potential <typeparamref name="TError"/>.
+        /// </summary>
+        /// <remarks>
+        /// Verify with <see cref="HasError"/> before using this, unless your certain that the error exists.
+        /// </remarks>
+        /// <example>
+        /// <code language="c#">
+        /// if (Either.HasError)
+        /// {
+        ///     // Safe to use.
+        ///     Console.WriteLine(Either.Error)
+        /// }
+        /// </code>
+        /// </example>
         public TError Error { get; }
+
+        /// <summary>
+        /// The potential <typeparamref name="T"/>.
+        /// </summary>
+        /// <remarks>
+        /// Verify with <see cref="HasValue"/> before using this, unless your certain that the value exists.
+        /// </remarks>
+        /// <example>
+        /// <code language="c#">
+        /// if (Either.HasValue)
+        /// {
+        ///     // Safe to use.
+        ///     Console.WriteLine(Either.Value)
+        /// }
+        /// </code>
+        /// </example>
         public T Value { get; }
 
         public Either(in T value, in TError error, bool hasError, bool hasValue) {

--- a/src/Lemonad.ErrorHandling/Maybe.cs
+++ b/src/Lemonad.ErrorHandling/Maybe.cs
@@ -21,8 +21,8 @@ namespace Lemonad.ErrorHandling {
         internal T Value { get; }
 
         private Maybe(Result<T, Unit> result) {
-            HasValue = result.HasValue;
-            Value = result.Value;
+            HasValue = result.Either.HasValue;
+            Value = result.Either.Value;
             _result = result;
         }
 

--- a/src/Lemonad.ErrorHandling/ResultExtensions.cs
+++ b/src/Lemonad.ErrorHandling/ResultExtensions.cs
@@ -225,7 +225,7 @@ namespace Lemonad.ErrorHandling {
         /// </typeparam>
         [Pure]
         public static Maybe<T> ToMaybe<T, TError>(this Result<T, TError> source) =>
-            source.HasValue ? source.Value : Maybe<T>.None;
+            source.Either.HasValue ? source.Either.Value : Maybe<T>.None;
 
         /// <summary>
         ///     Converts an <see cref="Nullable{T}" /> to an <see cref="Result{T,TError}" /> with the value
@@ -322,13 +322,13 @@ namespace Lemonad.ErrorHandling {
             enumerable.SelectMany(x => x.ToEnumerable());
 
         private static IEnumerable<TError> YieldErrors<T, TError>(Result<T, TError> result) {
-            if (result.HasError)
-                yield return result.Error;
+            if (result.Either.HasError)
+                yield return result.Either.Error;
         }
 
         private static IEnumerable<T> YieldValues<T, TError>(Result<T, TError> result) {
-            if (result.HasValue)
-                yield return result.Value;
+            if (result.Either.HasValue)
+                yield return result.Either.Value;
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/EitherTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/EitherTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Xunit;
+
+namespace Lemonad.ErrorHandling.Test {
+    public class EitherTests {
+        [Fact]
+        public void String_Int_Either_With_Value() {
+            var value = "foo";
+            var error = 2;
+            var either = new Either<string, int>(value: in value, error: in error, hasError: false, hasValue: true);
+            Assert.Equal("foo", either.Value);
+            Assert.Equal(2, either.Error);
+            Assert.NotEqual(either.HasError, either.HasValue);
+            Assert.True(either.HasValue);
+        }
+
+        [Fact]
+        public void String_Int_Either_With_Error() {
+            var value = "foo";
+            var error = 2;
+            var either = new Either<string, int>(value: in value, error: in error, hasError: true, hasValue: false);
+            Assert.Equal("foo", either.Value);
+            Assert.Equal(2, either.Error);
+            Assert.NotEqual(either.HasError, either.HasValue);
+            Assert.True(either.HasError);
+        }
+
+        /// <summary>
+        /// Would be nice if this was not allowed.
+        /// </summary>
+        [Fact]
+        public void String_Int_Either_With_Null_Error() {
+            var value = "foo";
+            int? error = null;
+            var either = new Either<string, int?>(value: in value, error: in error, hasError: true, hasValue: false);
+            Assert.Equal("foo", either.Value);
+            Assert.Null(either.Error);
+            Assert.NotEqual(either.HasError, either.HasValue);
+            Assert.True(either.HasError);
+        }
+
+        /// <summary>
+        /// Would be nice if this was not allowed.
+        /// </summary>
+        [Fact]
+        public void String_Int_Either_With_Null_Value() {
+            string value = null;
+            var error = 2;
+            var either = new Either<string, int>(value: in value, error: in error, hasError: true, hasValue: false);
+            Assert.Null(either.Value);
+            Assert.Equal(2, either.Error);
+            Assert.NotEqual(either.HasError, either.HasValue);
+            Assert.True(either.HasError);
+        }
+
+        [Fact]
+        public void String_Int_Either_With_Error_And_Value_Throws() {
+            var value = "foo";
+            var error = 2;
+            Assert.Throws<ArgumentException>(() =>
+                new Either<string, int>(value: in value, error: in error, hasError: true, hasValue: true));
+        }
+    }
+}

--- a/test/Lemonad.ErrorHandling.Test/Lemonad.ErrorHandling.Test.csproj
+++ b/test/Lemonad.ErrorHandling.Test/Lemonad.ErrorHandling.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/CastErrorTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/CastErrorTests.cs
@@ -22,43 +22,43 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         [Fact]
         public void Result_With_Error__With_Invalid_Casting() {
             var programResult = Program(1);
-            Assert.False(programResult.HasValue, "Result should not have value");
-            Assert.True(programResult.HasError, "Result should have error");
-            Assert.Equal(default, programResult.Value);
-            Assert.Equal(ExitCodes.Fail, programResult.Error);
+            Assert.False(programResult.Either.HasValue, "Result should not have value");
+            Assert.True(programResult.Either.HasError, "Resultction ReSharperGotoNextErrorInSolution should have error");
+            Assert.Equal(default, programResult.Either.Value);
+            Assert.Equal(ExitCodes.Fail, programResult.Either.Error);
             Assert.Throws<InvalidCastException>(() => programResult.CastError<string>());
         }
 
         [Fact]
         public void Result_With_Error__With_Valid_Casting() {
             var programResult = Program(1);
-            Assert.False(programResult.HasValue, "Result should not have value");
-            Assert.True(programResult.HasError, "Result should have error");
-            Assert.Equal(default, programResult.Value);
-            Assert.Equal(ExitCodes.Fail, programResult.Error);
+            Assert.False(programResult.Either.HasValue, "Result should not have value");
+            Assert.True(programResult.Either.HasError, "Result should have error");
+            Assert.Equal(default, programResult.Either.Value);
+            Assert.Equal(ExitCodes.Fail, programResult.Either.Error);
 
             var castResult = programResult.CastError<int>();
 
-            Assert.False(castResult.HasValue, "Casted Result not should have value.");
-            Assert.True(castResult.HasError, "Casted Result should have error.");
-            Assert.Equal(default, castResult.Value);
-            Assert.Equal(1, castResult.Error);
+            Assert.False(castResult.Either.HasValue, "Casted Result not should have value.");
+            Assert.True(castResult.Either.HasError, "Casted Result should have error.");
+            Assert.Equal(default, castResult.Either.Value);
+            Assert.Equal(1, castResult.Either.Error);
         }
 
         [Fact]
         public void Result_With_Value__With_Invalid_Casting() {
             var programResult = Program(0);
-            Assert.True(programResult.HasValue, "Result should have value");
-            Assert.False(programResult.HasError, "Result should not have error");
-            Assert.Equal("Success", programResult.Value);
-            Assert.Equal(default, programResult.Error);
+            Assert.True(programResult.Either.HasValue, "Result should have value");
+            Assert.False(programResult.Either.HasError, "Result should not have error");
+            Assert.Equal("Success", programResult.Either.Value);
+            Assert.Equal(default, programResult.Either.Error);
 
             var exception = Record.Exception(() => {
                 var castResult = programResult.CastError<string>();
-                Assert.True(castResult.HasValue, "Result should have value");
-                Assert.False(castResult.HasError, "Result should not have error");
-                Assert.Equal("Success", castResult.Value);
-                Assert.Equal(default, castResult.Error);
+                Assert.True(castResult.Either.HasValue, "Result should have value");
+                Assert.False(castResult.Either.HasError, "Result should not have error");
+                Assert.Equal("Success", castResult.Either.Value);
+                Assert.Equal(default, castResult.Either.Error);
             });
             Assert.Null(exception);
         }
@@ -66,17 +66,17 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         [Fact]
         public void Result_With_Value__With_Valid_Casting() {
             var programResult = Program(0);
-            Assert.True(programResult.HasValue, "Result should have value");
-            Assert.False(programResult.HasError, "Result should not have error");
-            Assert.Equal("Success", programResult.Value);
-            Assert.Equal(default, programResult.Error);
+            Assert.True(programResult.Either.HasValue, "Result should have value");
+            Assert.False(programResult.Either.HasError, "Result should not have error");
+            Assert.Equal("Success", programResult.Either.Value);
+            Assert.Equal(default, programResult.Either.Error);
 
             var castResult = programResult.CastError<int>();
 
-            Assert.True(castResult.HasValue, "Casted Result should have value.");
-            Assert.False(castResult.HasError, "Casted Result should not have error.");
-            Assert.Equal(default, castResult.Error);
-            Assert.Equal("Success", castResult.Value);
+            Assert.True(castResult.Either.HasValue, "Casted Result should have value.");
+            Assert.False(castResult.Either.HasError, "Casted Result should not have error.");
+            Assert.Equal(default, castResult.Either.Error);
+            Assert.Equal("Success", castResult.Either.Value);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/CastTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/CastTests.cs
@@ -22,17 +22,17 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         [Fact]
         public void Result_With_Error__With_Invalid_Casting() {
             var genderResult = GetGender(3);
-            Assert.False(genderResult.HasValue, "Result should not have value");
-            Assert.True(genderResult.HasError, "Result should have error");
-            Assert.Equal(default, genderResult.Value);
-            Assert.Equal("Could not determine gender", genderResult.Error);
+            Assert.False(genderResult.Either.HasValue, "Result should not have value");
+            Assert.True(genderResult.Either.HasError, "Result should have error");
+            Assert.Equal(default, genderResult.Either.Value);
+            Assert.Equal("Could not determine gender", genderResult.Either.Error);
 
             var exception = Record.Exception(() => {
                 var castResult = genderResult.Cast<string>();
-                Assert.False(castResult.HasValue, "Casted Result not should have value.");
-                Assert.True(castResult.HasError, "Casted Result should have error.");
-                Assert.Equal(default, castResult.Value);
-                Assert.Equal("Could not determine gender", castResult.Error);
+                Assert.False(castResult.Either.HasValue, "Casted Result not should have value.");
+                Assert.True(castResult.Either.HasError, "Casted Result should have error.");
+                Assert.Equal(default, castResult.Either.Value);
+                Assert.Equal("Could not determine gender", castResult.Either.Error);
             });
 
             Assert.Null(exception);
@@ -41,26 +41,26 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         [Fact]
         public void Result_With_Error__With_Valid_Casting() {
             var genderResult = GetGender(3);
-            Assert.False(genderResult.HasValue, "Result should not have value");
-            Assert.True(genderResult.HasError, "Result should have error");
-            Assert.Equal(default, genderResult.Value);
-            Assert.Equal("Could not determine gender", genderResult.Error);
+            Assert.False(genderResult.Either.HasValue, "Result should not have value");
+            Assert.True(genderResult.Either.HasError, "Result should have error");
+            Assert.Equal(default, genderResult.Either.Value);
+            Assert.Equal("Could not determine gender", genderResult.Either.Error);
 
             var castResult = genderResult.Cast<int>();
 
-            Assert.False(castResult.HasValue, "Casted Result not should have value.");
-            Assert.True(castResult.HasError, "Casted Result should have error.");
-            Assert.Equal(default, castResult.Value);
-            Assert.Equal("Could not determine gender", castResult.Error);
+            Assert.False(castResult.Either.HasValue, "Casted Result not should have value.");
+            Assert.True(castResult.Either.HasError, "Casted Result should have error.");
+            Assert.Equal(default, castResult.Either.Value);
+            Assert.Equal("Could not determine gender", castResult.Either.Error);
         }
 
         [Fact]
         public void Result_With_Value__With_Invalid_Casting() {
             var genderResult = GetGender(1);
-            Assert.True(genderResult.HasValue, "Result should have value");
-            Assert.False(genderResult.HasError, "Result should not have error");
-            Assert.Equal(Gender.Female, genderResult.Value);
-            Assert.Equal(default, genderResult.Error);
+            Assert.True(genderResult.Either.HasValue, "Result should have value");
+            Assert.False(genderResult.Either.HasError, "Result should not have error");
+            Assert.Equal(Gender.Female, genderResult.Either.Value);
+            Assert.Equal(default, genderResult.Either.Error);
 
             Assert.Throws<InvalidCastException>(() => genderResult.Cast<string>());
         }
@@ -68,17 +68,17 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         [Fact]
         public void Result_With_Value__With_Valid_Casting() {
             var genderResult = GetGender(1);
-            Assert.True(genderResult.HasValue, "Result should have value");
-            Assert.False(genderResult.HasError, "Result should not have error");
-            Assert.Equal(Gender.Female, genderResult.Value);
-            Assert.Equal(default, genderResult.Error);
+            Assert.True(genderResult.Either.HasValue, "Result should have value");
+            Assert.False(genderResult.Either.HasError, "Result should not have error");
+            Assert.Equal(Gender.Female, genderResult.Either.Value);
+            Assert.Equal(default, genderResult.Either.Error);
 
             var castResult = genderResult.Cast<int>();
 
-            Assert.True(castResult.HasValue, "Casted Result should have value.");
-            Assert.False(castResult.HasError, "Casted Result should not have error.");
-            Assert.Equal(1, castResult.Value);
-            Assert.Equal(default, castResult.Error);
+            Assert.True(castResult.Either.HasValue, "Casted Result should have value.");
+            Assert.False(castResult.Either.HasError, "Casted Result should not have error.");
+            Assert.Equal(1, castResult.Either.Value);
+            Assert.Equal(default, castResult.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/DoTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/DoTests.cs
@@ -10,10 +10,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             var result = Division(10, 0).Do(() => actionExectued = true);
 
             Assert.True(actionExectued, "Should not get exectued since there's an error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '10' with '0'.", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '10' with '0'.", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -22,10 +22,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             var result = Division(10, 2).Do(() => actionExectued = true);
 
             Assert.True(actionExectued, "Should not get exectued since there's an error.");
-            Assert.Equal(5, result.Value);
-            Assert.Equal(default, result.Error);
-            Assert.False(result.HasError, "Result should not have error.");
-            Assert.True(result.HasValue, "Result should have value.");
+            Assert.Equal(5, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
+            Assert.False(result.Either.HasError, "Result should not have error.");
+            Assert.True(result.Either.HasValue, "Result should have value.");
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/DoWithErrorTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/DoWithErrorTests.cs
@@ -10,10 +10,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             var result = Division(10, 0).DoWithError(d => actionExectued = true);
 
             Assert.True(actionExectued, "Should not get exectued since there's an error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '10' with '0'.", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '10' with '0'.", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -23,10 +23,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             var result = Division(10, 2).DoWithError(d => actionExectued = true);
 
             Assert.False(actionExectued, "Should not get exectued since there's an error.");
-            Assert.Equal(5, result.Value);
-            Assert.Equal(default, result.Error);
-            Assert.False(result.HasError, "Result should not have error.");
-            Assert.True(result.HasValue, "Result should have value.");
+            Assert.Equal(5, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
+            Assert.False(result.Either.HasError, "Result should not have error.");
+            Assert.True(result.Either.HasValue, "Result should have value.");
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/DoWithTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/DoWithTests.cs
@@ -10,10 +10,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             var result = Division(10, 0).DoWith(d => actionExectued = true);
 
             Assert.False(actionExectued, "Should not get exectued since there's an error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '10' with '0'.", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '10' with '0'.", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -23,10 +23,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             var result = Division(10, 2).DoWith(d => actionExectued = true);
 
             Assert.True(actionExectued, "Should not get exectued since there's an error.");
-            Assert.Equal(5, result.Value);
-            Assert.Equal(default, result.Error);
-            Assert.False(result.HasError, "Result should not have error.");
-            Assert.True(result.HasValue, "Result should have value.");
+            Assert.Equal(5, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
+            Assert.False(result.Either.HasError, "Result should not have error.");
+            Assert.True(result.Either.HasValue, "Result should have value.");
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/FilterTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/FilterTests.cs
@@ -20,10 +20,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Should not get exectued since there's an error before the predicate was applied.");
             Assert.False(errorSelectorExectued,
                 "Should not get exectued since there's an error before the predicate was applied.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '10' with '0'.", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '10' with '0'.", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -43,10 +43,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Should not get exectued since there's an error before the predicate was applied.");
             Assert.False(errorSelectorExectued,
                 "Should not get exectued since there's an error before the predicate was applied.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '10' with '0'.", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '10' with '0'.", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -64,10 +64,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.True(predicateExectued, "Should get exectued since there's a value from the result.");
             Assert.True(errorSelectorExectued, "Should get exectued since the predicate was truthy.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Bad", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Bad", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -86,10 +86,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.True(predicateExectued, "Should get exectued since there's a value from the result.");
             Assert.True(errorSelectorExectued, "Should get exectued since the predicate was truthy.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Good", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Good", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -109,10 +109,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Should get exectued since there's a value from the result.");
             Assert.False(errorSelectorExectued,
                 "Should not get exectued since the predicate was falsy.");
-            Assert.Equal(5, result.Value);
-            Assert.Equal(default, result.Error);
-            Assert.False(result.HasError, "Result should not have error.");
-            Assert.True(result.HasValue, "Result should have value.");
+            Assert.Equal(5, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
+            Assert.False(result.Either.HasError, "Result should not have error.");
+            Assert.True(result.Either.HasValue, "Result should have value.");
         }
 
         [Fact]
@@ -132,10 +132,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Should get exectued since there's a value from the result.");
             Assert.False(errorSelectorExectued,
                 "Should not get exectued since the predicate was falsy.");
-            Assert.Equal(5, result.Value);
-            Assert.Equal(default, result.Error);
-            Assert.False(result.HasError, "Result should not have error.");
-            Assert.True(result.HasValue, "Result should have value.");
+            Assert.Equal(5, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
+            Assert.False(result.Either.HasError, "Result should not have error.");
+            Assert.True(result.Either.HasValue, "Result should have value.");
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/FlatMapSameTErrorAsyncTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/FlatMapSameTErrorAsyncTests.cs
@@ -15,10 +15,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -31,10 +31,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -53,10 +53,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -74,10 +74,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -93,10 +93,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -109,10 +109,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             });
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(0.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(0.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -131,14 +131,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -155,10 +155,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             Assert.True(flatSelectorExecuted, "Flatmapselecotr should get executed.");
             Assert.True(resultSelectorExectued,
                 "ResultSelector should get executed since both source and the result from flatmapselector contains values.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/FlatMapTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/FlatMapTests.cs
@@ -19,10 +19,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -41,10 +41,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -69,10 +69,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -97,10 +97,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -122,10 +122,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -141,10 +141,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             });
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(0.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(0.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -169,14 +169,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -199,10 +199,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "ResultSelector should get executed since both source and the result from flatmapselector contains values.");
             Assert.False(errorSelectorExecuted,
                 "Erroselector should not get executed since both source and the result from flatmapselector contains values.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/FlatMapTestsSameTError.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/FlatMapTestsSameTError.cs
@@ -13,10 +13,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -29,10 +29,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -51,10 +51,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -72,10 +72,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -91,10 +91,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -107,10 +107,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             });
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(0.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(0.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -129,14 +129,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -153,10 +153,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             Assert.True(flatSelectorExecuted, "Flatmapselecotr should get executed.");
             Assert.True(resultSelectorExectued,
                 "ResultSelector should get executed since both source and the result from flatmapselector contains values.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/FlatmapAsyncTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/FlatmapAsyncTests.cs
@@ -21,10 +21,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -43,10 +43,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -71,10 +71,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -99,10 +99,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -124,10 +124,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -143,10 +143,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             });
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(0.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(0.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -171,14 +171,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -201,10 +201,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "ResultSelector should get executed since both source and the result from flatmapselector contains values.");
             Assert.False(errorSelectorExecuted,
                 "Erroselector should not get executed since both source and the result from flatmapselector contains values.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/FlattenAsyncTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/FlattenAsyncTests.cs
@@ -37,10 +37,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -55,10 +55,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -79,10 +79,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -98,10 +98,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -122,10 +122,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should not exeuted since the errror came from the result given to the flatselector.");
             Assert.True(flatSelectorExecuted,
                 "The flatmapSelector should get exectued.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -140,10 +140,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.True(flatSelectorExecuted,
                 "The flatmapSelector should get exectued.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -162,10 +162,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             var result = await flattenAsync;
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -178,10 +178,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             });
             var result = await flattenAsync;
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -202,14 +202,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             Assert.True(errorSelectorExecuted,
                 "Errorselector should get exeuted since the errror came from the result given to the flatselector.");
             Assert.True(flatSelectorExecuted);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -224,14 +224,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             var result = await flattenAsync;
 
             Assert.True(flatSelectorExecuted);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/FlattenTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/FlattenTests.cs
@@ -18,11 +18,11 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             Assert.False(errorSelectorExecuted,
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
-                "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+                "The flatmap selector should not get exectued if the sourcegeiEither. Result<T, TError> contains error.");
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -35,10 +35,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -57,10 +57,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -73,10 +73,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -95,10 +95,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should not exeuted since the errror came from the result given to the flatselector.");
             Assert.True(flatSelectorExecuted,
                 "The flatmapSelector should get exectued.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -111,10 +111,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.True(flatSelectorExecuted,
                 "The flatmapSelector should get exectued.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -130,10 +130,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             });
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -144,10 +144,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 return Division(x, 2);
             });
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -166,14 +166,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should get exeuted since the errror came from the result given to the flatselector.");
             Assert.True(flatSelectorExecuted,
                 "The flatselector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -186,14 +186,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.True(flatSelectorExecuted,
                 "The flatselector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/FullCastTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/FullCastTests.cs
@@ -26,145 +26,145 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         [Fact]
         public void Result_With_Error__With_Invalid_Casting() {
             var programResult = Program(5);
-            Assert.False(programResult.HasValue, "ProgramResult should not have value");
-            Assert.True(programResult.HasError, "ProgramResult should have error");
-            Assert.Equal(Error.Fail, programResult.Error);
-            Assert.Equal(default, programResult.Value);
+            Assert.False(programResult.Either.HasValue, "ProgramResult should not have value");
+            Assert.True(programResult.Either.HasError, "ProgramResult should have error");
+            Assert.Equal(Error.Fail, programResult.Either.Error);
+            Assert.Equal(default, programResult.Either.Value);
             Assert.Throws<InvalidCastException>(() => programResult.FullCast<string>());
         }
 
         [Fact]
         public void Result_With_Error__With_Invalid_Value_Casting_And_Invalid_Error_Casting() {
             var programResult = Program(5);
-            Assert.False(programResult.HasValue, "ProgramResult should not have value");
-            Assert.True(programResult.HasError, "ProgramResult should have error");
-            Assert.Equal(Error.Fail, programResult.Error);
-            Assert.Equal(default, programResult.Value);
+            Assert.False(programResult.Either.HasValue, "ProgramResult should not have value");
+            Assert.True(programResult.Either.HasError, "ProgramResult should have error");
+            Assert.Equal(Error.Fail, programResult.Either.Error);
+            Assert.Equal(default, programResult.Either.Value);
             Assert.Throws<InvalidCastException>(() => programResult.FullCast<string, string>());
         }
 
         [Fact]
         public void Result_With_Error__With_Invalid_Value_Casting_And_Valid_Error_Casting() {
             var programResult = Program(5);
-            Assert.False(programResult.HasValue, "ProgramResult should not have value");
-            Assert.True(programResult.HasError, "ProgramResult should have error");
-            Assert.Equal(Error.Fail, programResult.Error);
-            Assert.Equal(default, programResult.Value);
+            Assert.False(programResult.Either.HasValue, "ProgramResult should not have value");
+            Assert.True(programResult.Either.HasError, "ProgramResult should have error");
+            Assert.Equal(Error.Fail, programResult.Either.Error);
+            Assert.Equal(default, programResult.Either.Value);
             var castResult = programResult.FullCast<string, int>();
-            Assert.False(castResult.HasValue, "CastResult should not have value");
-            Assert.True(castResult.HasError, "CastResult should have error");
-            Assert.Equal(1, castResult.Error);
-            Assert.Equal(default, castResult.Value);
+            Assert.False(castResult.Either.HasValue, "CastResult should not have value");
+            Assert.True(castResult.Either.HasError, "CastResult should have error");
+            Assert.Equal(1, castResult.Either.Error);
+            Assert.Equal(default, castResult.Either.Value);
         }
 
         [Fact]
         public void Result_With_Error__With_Valid_Casting() {
             var programResult = Program(5);
-            Assert.False(programResult.HasValue, "ProgramResult should not have value");
-            Assert.True(programResult.HasError, "ProgramResult should have error");
-            Assert.Equal(Error.Fail, programResult.Error);
-            Assert.Equal(default, programResult.Value);
+            Assert.False(programResult.Either.HasValue, "ProgramResult should not have value");
+            Assert.True(programResult.Either.HasError, "ProgramResult should have error");
+            Assert.Equal(Error.Fail, programResult.Either.Error);
+            Assert.Equal(default, programResult.Either.Value);
             var castResult = programResult.FullCast<int>();
-            Assert.False(castResult.HasValue, "CastResult should not have value");
-            Assert.True(castResult.HasError, "CastResult should have error");
-            Assert.Equal(1, castResult.Error);
-            Assert.Equal(default, castResult.Value);
+            Assert.False(castResult.Either.HasValue, "CastResult should not have value");
+            Assert.True(castResult.Either.HasError, "CastResult should have error");
+            Assert.Equal(1, castResult.Either.Error);
+            Assert.Equal(default, castResult.Either.Value);
         }
 
         [Fact]
         public void Result_With_Error__With_Valid_Value_Casting_And_Invalid_Error_Casting() {
             var programResult = Program(5);
-            Assert.False(programResult.HasValue, "ProgramResult should not have value");
-            Assert.True(programResult.HasError, "ProgramResult should have error");
-            Assert.Equal(Error.Fail, programResult.Error);
-            Assert.Equal(default, programResult.Value);
+            Assert.False(programResult.Either.HasValue, "ProgramResult should not have value");
+            Assert.True(programResult.Either.HasError, "ProgramResult should have error");
+            Assert.Equal(Error.Fail, programResult.Either.Error);
+            Assert.Equal(default, programResult.Either.Value);
             Assert.Throws<InvalidCastException>(() => programResult.FullCast<int, string>());
         }
 
         [Fact]
         public void Result_With_Error__With_Valid_Value_Casting_And_Valid_Error_Casting() {
             var programResult = Program(5);
-            Assert.False(programResult.HasValue, "ProgramResult should not have value");
-            Assert.True(programResult.HasError, "ProgramResult should have error");
-            Assert.Equal(Error.Fail, programResult.Error);
-            Assert.Equal(default, programResult.Value);
+            Assert.False(programResult.Either.HasValue, "ProgramResult should not have value");
+            Assert.True(programResult.Either.HasError, "ProgramResult should have error");
+            Assert.Equal(Error.Fail, programResult.Either.Error);
+            Assert.Equal(default, programResult.Either.Value);
             var castResult = programResult.FullCast<int, int>();
-            Assert.False(castResult.HasValue, "CastResult should not have value");
-            Assert.True(castResult.HasError, "CastResult should have error");
-            Assert.Equal(1, castResult.Error);
-            Assert.Equal(default, castResult.Value);
+            Assert.False(castResult.Either.HasValue, "CastResult should not have value");
+            Assert.True(castResult.Either.HasError, "CastResult should have error");
+            Assert.Equal(1, castResult.Either.Error);
+            Assert.Equal(default, castResult.Either.Value);
         }
 
         [Fact]
         public void Result_With_Value__With_Invalid_Casting() {
             var programResult = Program(1);
-            Assert.True(programResult.HasValue, "ProgramResult should have value");
-            Assert.False(programResult.HasError, "ProgramResult should not have error");
-            Assert.Equal(default, programResult.Error);
-            Assert.Equal(Gender.Male, programResult.Value);
+            Assert.True(programResult.Either.HasValue, "ProgramResult should have value");
+            Assert.False(programResult.Either.HasError, "ProgramResult should not have error");
+            Assert.Equal(default, programResult.Either.Error);
+            Assert.Equal(Gender.Male, programResult.Either.Value);
             Assert.Throws<InvalidCastException>(() => programResult.FullCast<string>());
         }
 
         [Fact]
         public void Result_With_Value__With_Invalid_Value_Casting_And_Invalid_Error_Casting() {
             var programResult = Program(1);
-            Assert.True(programResult.HasValue, "ProgramResult should have value");
-            Assert.False(programResult.HasError, "ProgramResult should not have error");
-            Assert.Equal(default, programResult.Error);
-            Assert.Equal(Gender.Male, programResult.Value);
+            Assert.True(programResult.Either.HasValue, "ProgramResult should have value");
+            Assert.False(programResult.Either.HasError, "ProgramResult should not have error");
+            Assert.Equal(default, programResult.Either.Error);
+            Assert.Equal(Gender.Male, programResult.Either.Value);
             Assert.Throws<InvalidCastException>(() => programResult.FullCast<string, string>());
         }
 
         [Fact]
         public void Result_With_Value__With_Invalid_Value_Casting_And_Valid_Error_Casting() {
             var programResult = Program(1);
-            Assert.True(programResult.HasValue, "ProgramResult should have value");
-            Assert.False(programResult.HasError, "ProgramResult should not have error");
-            Assert.Equal(default, programResult.Error);
-            Assert.Equal(Gender.Male, programResult.Value);
+            Assert.True(programResult.Either.HasValue, "ProgramResult should have value");
+            Assert.False(programResult.Either.HasError, "ProgramResult should not have error");
+            Assert.Equal(default, programResult.Either.Error);
+            Assert.Equal(Gender.Male, programResult.Either.Value);
             Assert.Throws<InvalidCastException>(() => programResult.FullCast<string, int>());
         }
 
         [Fact]
         public void Result_With_Value__With_Valid_Casting() {
             var programResult = Program(1);
-            Assert.True(programResult.HasValue, "ProgramResult should have value");
-            Assert.False(programResult.HasError, "ProgramResult should not have error");
-            Assert.Equal(default, programResult.Error);
-            Assert.Equal(Gender.Male, programResult.Value);
+            Assert.True(programResult.Either.HasValue, "ProgramResult should have value");
+            Assert.False(programResult.Either.HasError, "ProgramResult should not have error");
+            Assert.Equal(default, programResult.Either.Error);
+            Assert.Equal(Gender.Male, programResult.Either.Value);
             var castResult = programResult.FullCast<int>();
-            Assert.True(castResult.HasValue, "CastResult should have value");
-            Assert.False(castResult.HasError, "CastResult should not have error");
-            Assert.Equal(default, castResult.Error);
-            Assert.Equal(1, castResult.Value);
+            Assert.True(castResult.Either.HasValue, "CastResult should have value");
+            Assert.False(castResult.Either.HasError, "CastResult should not have error");
+            Assert.Equal(default, castResult.Either.Error);
+            Assert.Equal(1, castResult.Either.Value);
         }
 
         [Fact]
         public void Result_With_Value__With_Valid_Value_Casting_And_Invalid_Error_Casting() {
             var programResult = Program(1);
-            Assert.True(programResult.HasValue, "ProgramResult should have value");
-            Assert.False(programResult.HasError, "ProgramResult should not have error");
-            Assert.Equal(default, programResult.Error);
-            Assert.Equal(Gender.Male, programResult.Value);
+            Assert.True(programResult.Either.HasValue, "ProgramResult should have value");
+            Assert.False(programResult.Either.HasError, "ProgramResult should not have error");
+            Assert.Equal(default, programResult.Either.Error);
+            Assert.Equal(Gender.Male, programResult.Either.Value);
             var castResult = programResult.FullCast<int, string>();
-            Assert.True(castResult.HasValue, "CastResult should have value");
-            Assert.False(castResult.HasError, "CastResult should not have error");
-            Assert.Equal(default, castResult.Error);
-            Assert.Equal(1, castResult.Value);
+            Assert.True(castResult.Either.HasValue, "CastResult should have value");
+            Assert.False(castResult.Either.HasError, "CastResult should not have error");
+            Assert.Equal(default, castResult.Either.Error);
+            Assert.Equal(1, castResult.Either.Value);
         }
 
         [Fact]
         public void Result_With_Value__With_Valid_Value_Casting_And_Valid_Error_Casting() {
             var programResult = Program(1);
-            Assert.True(programResult.HasValue, "ProgramResult should have value");
-            Assert.False(programResult.HasError, "ProgramResult should not have error");
-            Assert.Equal(default, programResult.Error);
-            Assert.Equal(Gender.Male, programResult.Value);
+            Assert.True(programResult.Either.HasValue, "ProgramResult should have value");
+            Assert.False(programResult.Either.HasError, "ProgramResult should not have error");
+            Assert.Equal(default, programResult.Either.Error);
+            Assert.Equal(Gender.Male, programResult.Either.Value);
             var castResult = programResult.FullCast<int, int>();
-            Assert.True(castResult.HasValue, "CastResult should have value");
-            Assert.False(castResult.HasError, "CastResult should not have error");
-            Assert.Equal(default, castResult.Error);
-            Assert.Equal(1, castResult.Value);
+            Assert.True(castResult.Either.HasValue, "CastResult should have value");
+            Assert.False(castResult.Either.HasError, "CastResult should not have error");
+            Assert.Equal(default, castResult.Either.Error);
+            Assert.Equal(1, castResult.Either.Value);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/FullFlatMapAsyncTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/FullFlatMapAsyncTests.cs
@@ -21,10 +21,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -43,10 +43,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should get exeuted since there is an error in the source..");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -71,10 +71,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -99,10 +99,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -124,10 +124,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -143,10 +143,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             });
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(0.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(0.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -171,14 +171,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -201,10 +201,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "ResultSelector should get executed since both source and the result from flatmapselector contains values.");
             Assert.False(errorSelectorExecuted,
                 "Erroselector should not get executed since both source and the result from flatmapselector contains values.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/FullFlatMapTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/FullFlatMapTests.cs
@@ -19,10 +19,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -41,10 +41,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Errorselector should get exeuted since there is an error in the source..");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -69,10 +69,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -97,10 +97,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -122,10 +122,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -141,10 +141,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             });
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(0.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(0.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -169,14 +169,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -199,10 +199,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "ResultSelector should get executed since both source and the result from flatmapselector contains values.");
             Assert.False(errorSelectorExecuted,
                 "Erroselector should not get executed since both source and the result from flatmapselector contains values.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/FullMapTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/FullMapTests.cs
@@ -17,10 +17,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.False(selectorExectued, "Should not get exectued since there's an error from the result.");
             Assert.True(errorSelectorExectued, "Should get exectued since there's an error from the result.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("CAN NOT DIVIDE '10' WITH '0'.", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("CAN NOT DIVIDE '10' WITH '0'.", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -37,10 +37,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.True(selectorExectued, "Should get exectued since there's an value from the result.");
             Assert.False(errorSelectorExectued, "Should not get exectued since there's an value from the result.");
-            Assert.Equal(50, result.Value);
-            Assert.Equal(default, result.Error);
-            Assert.False(result.HasError, "Result should not have error.");
-            Assert.True(result.HasValue, "Result should have value.");
+            Assert.Equal(50, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
+            Assert.False(result.Either.HasError, "Result should not have error.");
+            Assert.True(result.Either.HasValue, "Result should have value.");
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/CastErrorTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/CastErrorTests.cs
@@ -17,10 +17,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var programResult = AssertionUtilities.Program(1);
             var castResult =
                 await TaskResultFunctions.CastError<string, AssertionUtilities.ExitCodes, int>(programResult);
-            Assert.False(castResult.HasValue, "Casted Result not should have value.");
-            Assert.True(castResult.HasError, "Casted Result should have error.");
-            Assert.Equal(default, castResult.Value);
-            Assert.Equal(1, castResult.Error);
+            Assert.False(castResult.Either.HasValue, "Casted Result not should have value.");
+            Assert.True(castResult.Either.HasError, "Casted Result should have error.");
+            Assert.Equal(default, castResult.Either.Value);
+            Assert.Equal(1, castResult.Either.Error);
         }
 
         [Fact]
@@ -30,10 +30,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var exception = await Record.ExceptionAsync(async () => {
                 var castResult =
                     await TaskResultFunctions.CastError<string, AssertionUtilities.ExitCodes, string>(programResult);
-                Assert.True(castResult.HasValue, "Result should have value");
-                Assert.False(castResult.HasError, "Result should not have error");
-                Assert.Equal("Success", castResult.Value);
-                Assert.Equal(default, castResult.Error);
+                Assert.True(castResult.Either.HasValue, "Result should have value");
+                Assert.False(castResult.Either.HasError, "Result should not have error");
+                Assert.Equal("Success", castResult.Either.Value);
+                Assert.Equal(default, castResult.Either.Error);
             });
             Assert.Null(exception);
         }
@@ -45,10 +45,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var castResult =
                 await TaskResultFunctions.CastError<string, AssertionUtilities.ExitCodes, int>(programResult);
 
-            Assert.True(castResult.HasValue, "Casted Result should have value.");
-            Assert.False(castResult.HasError, "Casted Result should not have error.");
-            Assert.Equal(default, castResult.Error);
-            Assert.Equal("Success", castResult.Value);
+            Assert.True(castResult.Either.HasValue, "Casted Result should have value.");
+            Assert.False(castResult.Either.HasError, "Casted Result should not have error.");
+            Assert.Equal(default, castResult.Either.Error);
+            Assert.Equal("Success", castResult.Either.Value);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/CastTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/CastTests.cs
@@ -11,10 +11,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var exception = await Record.ExceptionAsync(async () => {
                 var result = TaskResultFunctions.Cast<AssertionUtilities.Gender, int, string>(genderResult);
                 var castResult = await result;
-                Assert.False(castResult.HasValue, "Casted Result not should have value.");
-                Assert.True(castResult.HasError, "Casted Result should have error.");
-                Assert.Equal(default, castResult.Value);
-                Assert.Equal("Could not determine gender", castResult.Error);
+                Assert.False(castResult.Either.HasValue, "Casted Result not should have value.");
+                Assert.True(castResult.Either.HasError, "Casted Result should have error.");
+                Assert.Equal(default, castResult.Either.Value);
+                Assert.Equal("Could not determine gender", castResult.Either.Error);
             });
 
             Assert.Null(exception);
@@ -26,10 +26,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             var castResult = await TaskResultFunctions.Cast<AssertionUtilities.Gender, int, string>(genderResult);
 
-            Assert.False(castResult.HasValue, "Casted Result not should have value.");
-            Assert.True(castResult.HasError, "Casted Result should have error.");
-            Assert.Equal(default, castResult.Value);
-            Assert.Equal("Could not determine gender", castResult.Error);
+            Assert.False(castResult.Either.HasValue, "Casted Result not should have value.");
+            Assert.True(castResult.Either.HasError, "Casted Result should have error.");
+            Assert.Equal(default, castResult.Either.Value);
+            Assert.Equal("Could not determine gender", castResult.Either.Error);
         }
 
         [Fact]
@@ -43,10 +43,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             var castResult = await TaskResultFunctions.Cast<AssertionUtilities.Gender, int, string>(genderResult);
 
-            Assert.True(castResult.HasValue, "Casted Result should have value.");
-            Assert.False(castResult.HasError, "Casted Result should not have error.");
-            Assert.Equal(1, castResult.Value);
-            Assert.Equal(default, castResult.Error);
+            Assert.True(castResult.Either.HasValue, "Casted Result should have value.");
+            Assert.False(castResult.Either.HasError, "Casted Result should not have error.");
+            Assert.Equal(1, castResult.Either.Value);
+            Assert.Equal(default, castResult.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/DoTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/DoTests.cs
@@ -13,10 +13,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await task;
 
             Assert.True(actionExectued, "Should not get exectued since there's an error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '10' with '0'.", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '10' with '0'.", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -26,10 +26,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await task;
 
             Assert.True(actionExectued, "Should not get exectued since there's an error.");
-            Assert.Equal(5, result.Value);
-            Assert.Equal(default, result.Error);
-            Assert.False(result.HasError, "Result should not have error.");
-            Assert.True(result.HasValue, "Result should have value.");
+            Assert.Equal(5, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
+            Assert.False(result.Either.HasError, "Result should not have error.");
+            Assert.True(result.Either.HasValue, "Result should have value.");
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/DoWithErrorTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/DoWithErrorTests.cs
@@ -13,10 +13,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await doWithError;
 
             Assert.True(actionExectued, "Should get exectued since there's an error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '10' with '0'.", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '10' with '0'.", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -28,10 +28,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await doWithError;
 
             Assert.False(actionExectued, "Should not get exectued since there's no error.");
-            Assert.Equal(5, result.Value);
-            Assert.Equal(default, result.Error);
-            Assert.False(result.HasError, "Result should not have error.");
-            Assert.True(result.HasValue, "Result should have value.");
+            Assert.Equal(5, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
+            Assert.False(result.Either.HasError, "Result should not have error.");
+            Assert.True(result.Either.HasValue, "Result should have value.");
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/DoWithTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/DoWithTests.cs
@@ -13,10 +13,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await doWith;
 
             Assert.False(actionExectued, "Should not get exectued since there's an error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '10' with '0'.", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '10' with '0'.", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -28,10 +28,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await doWith;
 
             Assert.True(actionExectued, "Should get exectued since there's no error.");
-            Assert.Equal(5, result.Value);
-            Assert.Equal(default, result.Error);
-            Assert.False(result.HasError, "Result should not have error.");
-            Assert.True(result.HasValue, "Result should have value.");
+            Assert.Equal(5, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
+            Assert.False(result.Either.HasError, "Result should not have error.");
+            Assert.True(result.Either.HasValue, "Result should have value.");
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FilterTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FilterTests.cs
@@ -22,10 +22,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Should not get exectued since there's an error before the predicate was applied.");
             Assert.False(errorSelectorExectued,
                 "Should not get exectued since there's an error before the predicate was applied.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '10' with '0'.", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '10' with '0'.", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -44,10 +44,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.True(predicateExectued, "Should get exectued since there's a value from the result.");
             Assert.True(errorSelectorExectued, "Should get exectued since the predicate was truthy.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Bad", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Bad", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -69,10 +69,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Should get exectued since there's a value from the result.");
             Assert.False(errorSelectorExectued,
                 "Should not get exectued since the predicate was falsy.");
-            Assert.Equal(5, result.Value);
-            Assert.Equal(default, result.Error);
-            Assert.False(result.HasError, "Result should not have error.");
-            Assert.True(result.HasValue, "Result should have value.");
+            Assert.Equal(5, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
+            Assert.False(result.Either.HasError, "Result should not have error.");
+            Assert.True(result.Either.HasValue, "Result should have value.");
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FlatMapTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FlatMapTests.cs
@@ -20,10 +20,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -42,10 +42,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -64,10 +64,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -86,10 +86,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -114,10 +114,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -142,10 +142,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -170,10 +170,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -198,10 +198,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -224,10 +224,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -250,10 +250,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -270,10 +270,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await flatMap;
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(0.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(0.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -290,10 +290,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await flatMap;
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(0.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(0.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -319,14 +319,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -352,14 +352,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -384,10 +384,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "ResultSelector should get executed since both source and the result from flatmapselector contains values.");
             Assert.False(errorSelectorExecuted,
                 "Erroselector should not get executed since both source and the result from flatmapselector contains values.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -412,10 +412,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "ResultSelector should get executed since both source and the result from flatmapselector contains values.");
             Assert.False(errorSelectorExecuted,
                 "Erroselector should not get executed since both source and the result from flatmapselector contains values.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FlatmapTestsSameTerror.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FlatmapTestsSameTerror.cs
@@ -14,10 +14,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -30,10 +30,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -46,10 +46,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -62,10 +62,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -84,10 +84,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -106,10 +106,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -127,10 +127,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -148,10 +148,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -169,10 +169,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -190,10 +190,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -207,10 +207,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await flatMap;
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(0.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(0.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -224,10 +224,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await flatMap;
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(0.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(0.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -247,14 +247,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -274,14 +274,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -299,10 +299,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             Assert.True(flatSelectorExecuted, "Flatmapselecotr should get executed.");
             Assert.True(resultSelectorExectued,
                 "ResultSelector should get executed since both source and the result from flatmapselector contains values.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -320,10 +320,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             Assert.True(flatSelectorExecuted, "Flatmapselecotr should get executed.");
             Assert.True(resultSelectorExectued,
                 "ResultSelector should get executed since both source and the result from flatmapselector contains values.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FlattenTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FlattenTests.cs
@@ -22,10 +22,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -46,10 +46,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -64,10 +64,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -82,10 +82,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -106,10 +106,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -130,10 +130,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should not get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -149,10 +149,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -168,10 +168,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -193,10 +193,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should not exeuted since the errror came from the result given to the flatselector.");
             Assert.True(flatSelectorExecuted,
                 "The flatmapSelector should get exectued.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -218,10 +218,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should not exeuted since the errror came from the result given to the flatselector.");
             Assert.True(flatSelectorExecuted,
                 "The flatmapSelector should get exectued.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -236,10 +236,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.True(flatSelectorExecuted,
                 "The flatmapSelector should get exectued.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -254,10 +254,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.True(flatSelectorExecuted,
                 "The flatmapSelector should get exectued.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -276,10 +276,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await flattenAsync;
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -298,10 +298,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await flattenAsync;
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -314,10 +314,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             });
             var result = await flattenAsync;
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -330,10 +330,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             });
             var result = await flattenAsync;
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -354,14 +354,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             Assert.True(errorSelectorExecuted,
                 "Errorselector should get exeuted since the errror came from the result given to the flatselector.");
             Assert.True(flatSelectorExecuted);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -382,14 +382,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             Assert.True(errorSelectorExecuted,
                 "Errorselector should get exeuted since the errror came from the result given to the flatselector.");
             Assert.True(flatSelectorExecuted);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -404,14 +404,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await flattenAsync;
 
             Assert.True(flatSelectorExecuted);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -426,14 +426,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await flattenAsync;
 
             Assert.True(flatSelectorExecuted);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FullFlatMapTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FullFlatMapTests.cs
@@ -21,10 +21,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -44,10 +44,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should get exeuted since there is an error in the source.");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -67,10 +67,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should get exeuted since there is an error in the source..");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -90,10 +90,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Errorselector should get exeuted since there is an error in the source..");
             Assert.False(flatSelectorExecuted,
                 "The flatmap selector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -119,10 +119,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -148,10 +148,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -177,10 +177,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -206,10 +206,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should not get exectued if the source Result<T, TError> contains error.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get exectued if the source Result<T, TError> contains error.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '2' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -232,10 +232,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -258,10 +258,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -278,10 +278,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await fullFlatMap;
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(0.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(0.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -298,10 +298,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await fullFlatMap;
             Assert.True(flatSelectorExecuted, "flatmapselector should get executed.");
             Assert.False(errorSelectorExecuted, "Errorselector should not get exeuted.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(0.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(0.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -327,14 +327,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -360,14 +360,14 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "The flatmapSelector should get exectued.");
             Assert.False(resultSelectorExectued,
                 "The resultSelector should not get executed since flatselector result failed.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '1' with '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '1' with '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -391,10 +391,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "ResultSelector should get executed since both source and the result from flatmapselector contains values.");
             Assert.False(errorSelectorExecuted,
                 "Erroselector should not get executed since both source and the result from flatmapselector contains values.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -418,10 +418,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "ResultSelector should get executed since both source and the result from flatmapselector contains values.");
             Assert.False(errorSelectorExecuted,
                 "Erroselector should not get executed since both source and the result from flatmapselector contains values.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(1.5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(1.5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FullMapTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/FullMapTests.cs
@@ -19,10 +19,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await task;
 
             Assert.False(selectorExectued, "Should not get exectued since there's an error from the result.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("CAN NOT DIVIDE '10' WITH '0'.", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("CAN NOT DIVIDE '10' WITH '0'.", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -41,10 +41,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.True(selectorExectued, "Should get exectued since there's an value from the result.");
             Assert.False(errorSelectorExectued, "Should not get exectued since there's an value from the result.");
-            Assert.Equal(50, result.Value);
-            Assert.Equal(default, result.Error);
-            Assert.False(result.HasError, "Result should not have error.");
-            Assert.True(result.HasValue, "Result should have value.");
+            Assert.Equal(50, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
+            Assert.False(result.Either.HasError, "Result should not have error.");
+            Assert.True(result.Either.HasValue, "Result should have value.");
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/IsErrorWhenTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/IsErrorWhenTests.cs
@@ -23,10 +23,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Should not get exectued since there's an error before the predicate was applied.");
             Assert.False(errorSelectorExectued,
                 "Should not get exectued since there's an error before the predicate was applied.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '10' with '0'.", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '10' with '0'.", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -48,10 +48,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
                 "Should get exectued since there's a value from the result.");
             Assert.False(errorSelectorExectued,
                 "Should not get exectued since the predicate was falsy.");
-            Assert.Equal(5, result.Value);
-            Assert.Equal(default, result.Error);
-            Assert.False(result.HasError, "Result should not have error.");
-            Assert.True(result.HasValue, "Result should have value.");
+            Assert.Equal(5, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
+            Assert.False(result.Either.HasError, "Result should not have error.");
+            Assert.True(result.Either.HasValue, "Result should have value.");
         }
 
         [Fact]
@@ -74,10 +74,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.True(predicateExectued, "Should get exectued since there's a value from the result.");
             Assert.True(errorSelectorExectued, "Should get exectued since the predicate was truthy.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Bad", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Bad", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/MapErrorTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/MapErrorTests.cs
@@ -15,10 +15,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var result = await task;
             Assert.True(errorSelectorInvoked,
                 "Errorselector should get exeuted since there is an error in the result.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("CAN NOT DIVIDE '10' WITH '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("CAN NOT DIVIDE '10' WITH '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -31,10 +31,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.False(errorSelectorInvoked,
                 "Errorselector not should get exeuted since there is an value in the result.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/MapTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/Internal.Asynchronous.Result.Tests/MapTests.cs
@@ -14,10 +14,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
 
             Assert.False(selectorExectued,
                 "The selector function should never get executed if there's no value in the Result<T, TError>.");
-            Assert.True(division.HasError, "Result should have error.");
-            Assert.False(division.HasValue, "Result should not have a value.");
-            Assert.Equal(default, division.Value);
-            Assert.Equal("Can not divide '2' with '0'.", division.Error);
+            Assert.True(division.Either.HasError, "Result should have error.");
+            Assert.False(division.Either.HasValue, "Result should not have a value.");
+            Assert.Equal(default, division.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", division.Either.Error);
         }
 
         [Fact]
@@ -31,10 +31,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests.Internal.Asynchronous.Result.T
             var division = await outcome;
 
             Assert.True(selectorExectued, "The selector function should get executed since the result has value.");
-            Assert.False(division.HasError, "Result not should have error.");
-            Assert.True(division.HasValue, "Result should have a value.");
-            Assert.Equal(20d, division.Value);
-            Assert.Equal(default, division.Error);
+            Assert.False(division.Either.HasError, "Result not should have error.");
+            Assert.True(division.Either.HasValue, "Result should have a value.");
+            Assert.Equal(20d, division.Either.Value);
+            Assert.Equal(default, division.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/IsErrorWhenTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/IsErrorWhenTests.cs
@@ -20,10 +20,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Should not get exectued since there's an error before the predicate was applied.");
             Assert.False(errorSelectorExectued,
                 "Should not get exectued since there's an error before the predicate was applied.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Can not divide '10' with '0'.", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Can not divide '10' with '0'.", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
 
         [Fact]
@@ -43,10 +43,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 "Should get exectued since there's a value from the result.");
             Assert.False(errorSelectorExectued,
                 "Should not get exectued since the predicate was falsy.");
-            Assert.Equal(5, result.Value);
-            Assert.Equal(default, result.Error);
-            Assert.False(result.HasError, "Result should not have error.");
-            Assert.True(result.HasValue, "Result should have value.");
+            Assert.Equal(5, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
+            Assert.False(result.Either.HasError, "Result should not have error.");
+            Assert.True(result.Either.HasValue, "Result should have value.");
         }
 
         [Fact]
@@ -64,10 +64,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.True(predicateExectued, "Should get exectued since there's a value from the result.");
             Assert.True(errorSelectorExectued, "Should get exectued since the predicate was truthy.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("Bad", result.Error);
-            Assert.True(result.HasError, "Result should have error.");
-            Assert.False(result.HasValue, "Result should not have value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("Bad", result.Either.Error);
+            Assert.True(result.Either.HasError, "Result should have error.");
+            Assert.False(result.Either.HasValue, "Result should not have value.");
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/JoinTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/JoinTests.cs
@@ -20,8 +20,8 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 return $"{x.Text} {y.Text}";
             }, () => string.Empty);
 
-            Assert.Equal(result.Value, default);
-            Assert.Equal(result.Error, "ERROR 1");
+            Assert.Equal(result.Either.Value, default);
+            Assert.Equal(result.Either.Error, "ERROR 1");
 
             Assert.False(outerSelectorInvoked, "outerSelectorInvoked");
             Assert.False(innerSelectorInvoked, "innerSelectorInvoked");
@@ -46,8 +46,8 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 return $"{x.Text} {y.Text}";
             }, () => string.Empty);
 
-            Assert.Equal(result.Value, default);
-            Assert.Equal(result.Error, "ERROR 1");
+            Assert.Equal(result.Either.Value, default);
+            Assert.Equal(result.Either.Error, "ERROR 1");
 
             Assert.False(outerSelectorInvoked, "outerSelectorInvoked");
             Assert.False(innerSelectorInvoked, "innerSelectorInvoked");
@@ -72,8 +72,8 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 return $"{x.Text} {y.Text}";
             }, () => string.Empty);
 
-            Assert.Equal(result.Value, default);
-            Assert.Equal(result.Error, "ERROR 2");
+            Assert.Equal(result.Either.Value, default);
+            Assert.Equal(result.Either.Error, "ERROR 2");
 
             Assert.False(outerSelectorInvoked, "outerSelectorInvoked");
             Assert.False(innerSelectorInvoked, "innerSelectorInvoked");
@@ -98,8 +98,8 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 return $"{x.Text} {y.Text}";
             }, () => "");
 
-            Assert.Equal(result.Value, "Hello world");
-            Assert.Equal(result.Error, default);
+            Assert.Equal(result.Either.Value, "Hello world");
+            Assert.Equal(result.Either.Error, default);
 
             Assert.True(outerSelectorInvoked, "outerSelectorInvoked");
             Assert.True(innerSelectorInvoked, "innerSelectorInvoked");
@@ -124,8 +124,8 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 return $"{x.Text} {y.Text}";
             }, () => "No key match");
 
-            Assert.Equal(result.Value, default);
-            Assert.Equal(result.Error, "No key match");
+            Assert.Equal(result.Either.Value, default);
+            Assert.Equal(result.Either.Error, "No key match");
 
             Assert.True(outerSelectorInvoked, "outerSelectorInvoked");
             Assert.True(innerSelectorInvoked, "innerSelectorInvoked");

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/MapErrorTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/MapErrorTests.cs
@@ -13,10 +13,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.True(errorSelectorInvoked,
                 "Errorselector should get exeuted since there is an error in the result.");
-            Assert.False(result.HasValue, "Result should not have a value.");
-            Assert.True(result.HasError, "Result should have a error.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("CAN NOT DIVIDE '10' WITH '0'.", result.Error);
+            Assert.False(result.Either.HasValue, "Result should not have a value.");
+            Assert.True(result.Either.HasError, "Result should have a error.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("CAN NOT DIVIDE '10' WITH '0'.", result.Either.Error);
         }
 
         [Fact]
@@ -29,10 +29,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.False(errorSelectorInvoked,
                 "Errorselector not should get exeuted since there is an value in the result.");
-            Assert.True(result.HasValue, "Result should have a value.");
-            Assert.False(result.HasError, "Result should not have a error.");
-            Assert.Equal(5d, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have a value.");
+            Assert.False(result.Either.HasError, "Result should not have a error.");
+            Assert.Equal(5d, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/MapTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/MapTests.cs
@@ -13,10 +13,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
 
             Assert.False(selectorExectued,
                 "The selector function should never get executed if there's no value in the Result<T, TError>.");
-            Assert.True(division.HasError, "Result should have error.");
-            Assert.False(division.HasValue, "Result should not have a value.");
-            Assert.Equal(default, division.Value);
-            Assert.Equal("Can not divide '2' with '0'.", division.Error);
+            Assert.True(division.Either.HasError, "Result should have error.");
+            Assert.False(division.Either.HasValue, "Result should not have a value.");
+            Assert.Equal(default, division.Either.Value);
+            Assert.Equal("Can not divide '2' with '0'.", division.Either.Error);
         }
 
         [Fact]
@@ -28,10 +28,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             });
 
             Assert.True(selectorExectued, "The selector function should get executed since the result has value.");
-            Assert.False(division.HasError, "Result not should have error.");
-            Assert.True(division.HasValue, "Result should have a value.");
-            Assert.Equal(20d, division.Value);
-            Assert.Equal(default, division.Error);
+            Assert.False(division.Either.HasError, "Result not should have error.");
+            Assert.True(division.Either.HasValue, "Result should have a value.");
+            Assert.Equal(20d, division.Either.Value);
+            Assert.Equal(default, division.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/MergeTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/MergeTests.cs
@@ -12,8 +12,8 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 return $"{x.Text} {y.Text}";
             });
 
-            Assert.Equal(result.Value, default);
-            Assert.Equal(result.Error, "ERROR 1");
+            Assert.Equal(result.Either.Value, default);
+            Assert.Equal(result.Either.Error, "ERROR 1");
             Assert.False(resultSelectorInvoked, "resultSelectorInvoked");
         }
 
@@ -27,8 +27,8 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 return $"{x.Text} {y.Text}";
             });
 
-            Assert.Equal(result.Value, default);
-            Assert.Equal(result.Error, "ERROR 1");
+            Assert.Equal(result.Either.Value, default);
+            Assert.Equal(result.Either.Error, "ERROR 1");
             Assert.False(resultSelectorInvoked, "resultSelectorInvoked");
         }
 
@@ -42,8 +42,8 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 return $"{x.Text} {y.Text}";
             });
 
-            Assert.Equal(result.Value, default);
-            Assert.Equal(result.Error, "ERROR 2");
+            Assert.Equal(result.Either.Value, default);
+            Assert.Equal(result.Either.Error, "ERROR 2");
             Assert.False(resultSelectorInvoked, "resultSelectorInvoked");
         }
 
@@ -57,8 +57,8 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 return $"{x.Text} {y.Text}";
             });
 
-            Assert.Equal(result.Value, "Hello world");
-            Assert.Equal(result.Error, default);
+            Assert.Equal(result.Either.Value, "Hello world");
+            Assert.Equal(result.Either.Error, default);
             Assert.True(resultSelectorInvoked, "resultSelectorInvoked");
         }
     }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/OfTypeTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/OfTypeTests.cs
@@ -23,10 +23,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         [Fact]
         public void Result_With_Error__With_Invalid_Casting() {
             var collectionResult = GetCollection(Collection.Unknown);
-            Assert.False(collectionResult.HasValue, "Result should not have value");
-            Assert.True(collectionResult.HasError, "Result should have error");
-            Assert.Equal(default, collectionResult.Value);
-            Assert.Equal("Could not obtain a collection.", collectionResult.Error);
+            Assert.False(collectionResult.Either.HasValue, "Result should not have value");
+            Assert.True(collectionResult.Either.HasError, "Result should have error");
+            Assert.Equal(default, collectionResult.Either.Value);
+            Assert.Equal("Could not obtain a collection.", collectionResult.Either.Error);
 
             var errorSelectorExectued = false;
             var castResult = collectionResult.SafeCast<double>(() => {
@@ -35,19 +35,19 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             });
 
             Assert.False(errorSelectorExectued, "Errorselector should not get executed");
-            Assert.False(castResult.HasValue, "Converted result should not have value");
-            Assert.True(castResult.HasError, "Converted Result should have error");
-            Assert.Equal(default, castResult.Value);
-            Assert.Equal("Could not obtain a collection.", castResult.Error);
+            Assert.False(castResult.Either.HasValue, "Converted result should not have value");
+            Assert.True(castResult.Either.HasError, "Converted Result should have error");
+            Assert.Equal(default, castResult.Either.Value);
+            Assert.Equal("Could not obtain a collection.", castResult.Either.Error);
         }
 
         [Fact]
         public void Result_With_Error__With_Valid_Casting() {
             var collectionResult = GetCollection(Collection.Unknown);
-            Assert.False(collectionResult.HasValue, "Result should not have value");
-            Assert.True(collectionResult.HasError, "Result should have error");
-            Assert.Equal(default, collectionResult.Value);
-            Assert.Equal("Could not obtain a collection.", collectionResult.Error);
+            Assert.False(collectionResult.Either.HasValue, "Result should not have value");
+            Assert.True(collectionResult.Either.HasError, "Result should have error");
+            Assert.Equal(default, collectionResult.Either.Value);
+            Assert.Equal("Could not obtain a collection.", collectionResult.Either.Error);
 
             var errorSelectorExectued = false;
             var castResult = collectionResult.SafeCast<int[]>(() => {
@@ -56,19 +56,19 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             });
 
             Assert.False(errorSelectorExectued, "Errorselector should not get executed");
-            Assert.False(castResult.HasValue, "Converted result should not have value");
-            Assert.True(castResult.HasError, "Converted Result should have error");
-            Assert.Equal(default, castResult.Value);
-            Assert.Equal("Could not obtain a collection.", castResult.Error);
+            Assert.False(castResult.Either.HasValue, "Converted result should not have value");
+            Assert.True(castResult.Either.HasError, "Converted Result should have error");
+            Assert.Equal(default, castResult.Either.Value);
+            Assert.Equal("Could not obtain a collection.", castResult.Either.Error);
         }
 
         [Fact]
         public void Result_With_Value__With_Invalid_Casting() {
             var collectionResult = GetCollection(Collection.Array);
-            Assert.True(collectionResult.HasValue, "Result should have value");
-            Assert.False(collectionResult.HasError, "Result should not have error");
-            Assert.IsType<int[]>(collectionResult.Value);
-            Assert.Equal(default, collectionResult.Error);
+            Assert.True(collectionResult.Either.HasValue, "Result should have value");
+            Assert.False(collectionResult.Either.HasError, "Result should not have error");
+            Assert.IsType<int[]>(collectionResult.Either.Value);
+            Assert.Equal(default, collectionResult.Either.Error);
 
             var errorSelectorExectued = false;
             var castResult = collectionResult.SafeCast<double>(() => {
@@ -77,19 +77,19 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             });
 
             Assert.True(errorSelectorExectued, "Errorselector should get executed");
-            Assert.False(castResult.HasValue, "Casted Result should not have value.");
-            Assert.True(castResult.HasError, "Casted Result should have error.");
-            Assert.Equal(default, castResult.Value);
-            Assert.Equal("Could not cast collection to double.", castResult.Error);
+            Assert.False(castResult.Either.HasValue, "Casted Result should not have value.");
+            Assert.True(castResult.Either.HasError, "Casted Result should have error.");
+            Assert.Equal(default, castResult.Either.Value);
+            Assert.Equal("Could not cast collection to double.", castResult.Either.Error);
         }
 
         [Fact]
         public void Result_With_Value__With_Valid_Casting() {
             var collectionResult = GetCollection(Collection.Array);
-            Assert.True(collectionResult.HasValue, "Result should have value");
-            Assert.False(collectionResult.HasError, "Result should not have error");
-            Assert.IsType<int[]>(collectionResult.Value);
-            Assert.Equal(default, collectionResult.Error);
+            Assert.True(collectionResult.Either.HasValue, "Result should have value");
+            Assert.False(collectionResult.Either.HasError, "Result should not have error");
+            Assert.IsType<int[]>(collectionResult.Either.Value);
+            Assert.Equal(default, collectionResult.Either.Error);
 
             var errorSelectorExectued = false;
             var castResult = collectionResult.SafeCast<int[]>(() => {
@@ -98,10 +98,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             });
 
             Assert.False(errorSelectorExectued, "Errorselector should not get executed");
-            Assert.True(castResult.HasValue, "Casted Result should have value.");
-            Assert.False(castResult.HasError, "Casted Result should not have error.");
-            Assert.Equal(new[] {1}, castResult.Value);
-            Assert.Equal(default, castResult.Error);
+            Assert.True(castResult.Either.HasValue, "Casted Result should have value.");
+            Assert.False(castResult.Either.HasError, "Casted Result should not have error.");
+            Assert.Equal(new[] {1}, castResult.Either.Value);
+            Assert.Equal(default, castResult.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/ToErrorTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/ToErrorTests.cs
@@ -7,10 +7,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         public void Convert_Int_To_ResultError() {
             var result = 2.ToResultError(i => true, () => "");
 
-            Assert.False(result.HasValue, "Result should have error.");
-            Assert.True(result.HasError, "Result should have a error value.");
-            Assert.Equal(2, result.Error);
-            Assert.Equal(default, result.Value);
+            Assert.False(result.Either.HasValue, "Result should have error.");
+            Assert.True(result.Either.HasError, "Result should have a error value.");
+            Assert.Equal(2, result.Either.Error);
+            Assert.Equal(default, result.Either.Value);
         }
 
         [Fact]
@@ -18,20 +18,20 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             string str = null;
             var result = str.ToResultError(x => true, () => "");
 
-            Assert.False(result.HasValue, "Result should have error.");
-            Assert.True(result.HasError, "Result should have a error value.");
-            Assert.Null(result.Error);
-            Assert.Equal(default, result.Value);
+            Assert.False(result.Either.HasValue, "Result should have error.");
+            Assert.True(result.Either.HasError, "Result should have a error value.");
+            Assert.Null(result.Either.Error);
+            Assert.Equal(default, result.Either.Value);
         }
 
         [Fact]
         public void Convert_String_To_ResultError() {
             var result = "hello".ToResultError(s => true, () => "");
 
-            Assert.False(result.HasValue, "Result should have value.");
-            Assert.True(result.HasError, "Result should have a error value.");
-            Assert.Equal("hello", result.Error);
-            Assert.Equal(default, result.Value);
+            Assert.False(result.Either.HasValue, "Result should have value.");
+            Assert.True(result.Either.HasError, "Result should have a error value.");
+            Assert.Equal("hello", result.Either.Error);
+            Assert.Equal(default, result.Either.Value);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/ToOkTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/ToOkTests.cs
@@ -6,10 +6,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         public void Convert_Int_To_ResultOk() {
             var result = 2.ToResult(x => true, () => "");
 
-            Assert.True(result.HasValue, "Result should have value.");
-            Assert.False(result.HasError, "Result should not have a error value.");
-            Assert.Equal(2, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have value.");
+            Assert.False(result.Either.HasError, "Result should not have a error value.");
+            Assert.Equal(2, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -17,19 +17,19 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             string str = null;
             var result = str.ToResult(x => true, () => "");
 
-            Assert.True(result.HasValue, "Result should have value.");
-            Assert.False(result.HasError, "Result should not have a error value.");
-            Assert.Null(result.Value);
+            Assert.True(result.Either.HasValue, "Result should have value.");
+            Assert.False(result.Either.HasError, "Result should not have a error value.");
+            Assert.Null(result.Either.Value);
         }
 
         [Fact]
         public void Convert_String_To_ResultOk() {
             var result = "hello".ToResult(x => true, () => "");
 
-            Assert.True(result.HasValue, "Result should have value.");
-            Assert.False(result.HasError, "Result should not have a error value.");
-            Assert.Equal("hello", result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have value.");
+            Assert.False(result.Either.HasError, "Result should not have a error value.");
+            Assert.Equal("hello", result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
     }
 }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/ToResultTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/ToResultTests.cs
@@ -7,10 +7,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         public void Convert_Maybe_Int_Whose_Property_HasValue_Is_False__Expects_Result_With_error_Value() {
             var result = 2.ToMaybeNone().ToResult(() => "ERROR");
 
-            Assert.False(result.HasValue, "Result should have error.");
-            Assert.True(result.HasError, "Result should have a error value.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("ERROR", result.Error);
+            Assert.False(result.Either.HasValue, "Result should have error.");
+            Assert.True(result.Either.HasError, "Result should have a error value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("ERROR", result.Either.Error);
         }
 
         [Fact]
@@ -26,10 +26,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         public void Convert_Maybe_Int_Whose_Property_HasValue_Is_True__Expects_Result_With_Ok_Value() {
             var result = 2.ToMaybe().ToResult(() => "ERROR");
 
-            Assert.True(result.HasValue, "Result should have value.");
-            Assert.False(result.HasError, "Result should not have a error value.");
-            Assert.Equal(2, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have value.");
+            Assert.False(result.Either.HasError, "Result should not have a error value.");
+            Assert.Equal(2, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -38,8 +38,8 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             var exception = Record.Exception(() => {
                 Func<int> errorSelector = null;
                 var result = 2.ToMaybe().ToResult(errorSelector);
-                Assert.True(result.HasValue, "Result should have value.");
-                Assert.Equal(2, result.Value);
+                Assert.True(result.Either.HasValue, "Result should have value.");
+                Assert.Equal(2, result.Either.Value);
             });
             Assert.Null(exception);
         }
@@ -48,39 +48,39 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         public void Convert_Maybe_String_Whose_Property_HasValue_Is_False__Expects_Result_With_error_Value() {
             var result = 2.ToMaybeNone().ToResult(() => "ERROR");
 
-            Assert.False(result.HasValue, "Result should have value.");
-            Assert.True(result.HasError, "Result should have a error value.");
-            Assert.Equal("ERROR", result.Error);
-            Assert.Equal(default, result.Value);
+            Assert.False(result.Either.HasValue, "Result should have value.");
+            Assert.True(result.Either.HasError, "Result should have a error value.");
+            Assert.Equal("ERROR", result.Either.Error);
+            Assert.Equal(default, result.Either.Value);
         }
 
         [Fact]
         public void Convert_Maybe_String_Whose_Property_HasValue_Is_True__Expects_Result_With_Ok_Value() {
             var result = 2.ToMaybe().ToResult(() => "ERROR");
 
-            Assert.True(result.HasValue, "Result should have value.");
-            Assert.False(result.HasError, "Result should not have a error value.");
-            Assert.Equal(default, result.Error);
-            Assert.Equal(2, result.Value);
+            Assert.True(result.Either.HasValue, "Result should have value.");
+            Assert.False(result.Either.HasError, "Result should not have a error value.");
+            Assert.Equal(default, result.Either.Error);
+            Assert.Equal(2, result.Either.Value);
         }
 
         [Fact]
         public void Convert_Maybe_String_With_Null_Whose_Property_HasValue_Is_False__Expects_Result_With_error_Value() {
             string str = null;
             var result = 2.ToMaybeNone().ToResult(() => str);
-            Assert.False(result.HasValue, "Result should have error.");
-            Assert.True(result.HasError, "Result should have a error value.");
-            Assert.Null(result.Error);
+            Assert.False(result.Either.HasValue, "Result should have error.");
+            Assert.True(result.Either.HasError, "Result should have a error value.");
+            Assert.Null(result.Either.Error);
         }
 
         [Fact]
         public void Convert_Maybe_String_With_Null_Whose_Property_HasValue_Is_True__Expects_Result_With_Ok_value() {
             string str = null;
             var result = 2.ToMaybe().ToResult(() => str);
-            Assert.True(result.HasValue, "Result should have value.");
-            Assert.False(result.HasError, "Result should not have a error value.");
-            Assert.Equal(2, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have value.");
+            Assert.False(result.Either.HasError, "Result should not have a error value.");
+            Assert.Equal(2, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -88,10 +88,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             int? number = null;
             var result = number.ToResult(() => "ERROR");
 
-            Assert.False(result.HasValue, "Result should have error.");
-            Assert.True(result.HasError, "Result should have a error value.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal("ERROR", result.Error);
+            Assert.False(result.Either.HasValue, "Result should have error.");
+            Assert.True(result.Either.HasError, "Result should have a error value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal("ERROR", result.Either.Error);
         }
 
         [Fact]
@@ -109,10 +109,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             int? number = 2;
             var result = number.ToResult(() => "ERROR");
 
-            Assert.True(result.HasValue, "Result should have value.");
-            Assert.False(result.HasError, "Result should not have a error value.");
-            Assert.Equal(2, result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.True(result.Either.HasValue, "Result should have value.");
+            Assert.False(result.Either.HasError, "Result should not have a error value.");
+            Assert.Equal(2, result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
         }
 
         [Fact]
@@ -122,8 +122,8 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
                 Func<int> errorSelector = null;
                 int? nullable = 2;
                 var result = nullable.ToResult(errorSelector);
-                Assert.True(result.HasValue, "Result should have value.");
-                Assert.Equal(2, result.Value);
+                Assert.True(result.Either.HasValue, "Result should have value.");
+                Assert.Equal(2, result.Either.Value);
             });
             Assert.Null(exception);
         }

--- a/test/Lemonad.ErrorHandling.Test/Result.Tests/ToStringTests.cs
+++ b/test/Lemonad.ErrorHandling.Test/Result.Tests/ToStringTests.cs
@@ -6,10 +6,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         public void Error_Result_With_Char__Expects_Char_To_have__Single_Quotes() {
             var result = 2.ToMaybeNone().ToResult(() => 'I');
 
-            Assert.True(result.HasError, "Result should have a error value.");
-            Assert.False(result.HasValue, "Result should not have a Ok value.");
-            Assert.Equal(default, result.Value);
-            Assert.Equal('I', result.Error);
+            Assert.True(result.Either.HasError, "Result should have a error value.");
+            Assert.False(result.Either.HasValue, "Result should not have a Ok value.");
+            Assert.Equal(default, result.Either.Value);
+            Assert.Equal('I', result.Either.Error);
             Assert.Equal("Error ==> Result<Int32, Char>('I')", result.ToString());
         }
 
@@ -18,10 +18,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
             string hello = null;
             var result = hello.ToMaybeNone().ToResult(() => 2);
 
-            Assert.True(result.HasError, "Result should have a error value.");
-            Assert.False(result.HasValue, "Result should not have a Ok value.");
-            Assert.Equal(2, result.Error);
-            Assert.Equal(default, result.Value);
+            Assert.True(result.Either.HasError, "Result should have a error value.");
+            Assert.False(result.Either.HasValue, "Result should not have a Ok value.");
+            Assert.Equal(2, result.Either.Error);
+            Assert.Equal(default, result.Either.Value);
             Assert.Equal("Error ==> Result<String, Int32>(2)", result.ToString());
         }
 
@@ -29,10 +29,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         public void Error_Result_With_String__Expects_String_To_have__Doble_Quotes() {
             var result = 2.ToMaybeNone().ToResult(() => "hello");
 
-            Assert.True(result.HasError, "Result should have a error value.");
-            Assert.False(result.HasValue, "Result should not have a Ok value.");
-            Assert.Equal("hello", result.Error);
-            Assert.Equal(default, result.Value);
+            Assert.True(result.Either.HasError, "Result should have a error value.");
+            Assert.False(result.Either.HasValue, "Result should not have a Ok value.");
+            Assert.Equal("hello", result.Either.Error);
+            Assert.Equal(default, result.Either.Value);
             Assert.Equal("Error ==> Result<Int32, String>(\"hello\")", result.ToString());
         }
 
@@ -40,10 +40,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         public void Ok_Result_With_Char__Expects_Char_To_have__Single_Quotes() {
             var result = 'I'.ToMaybe().ToResult(() => 2);
 
-            Assert.False(result.HasError, "Result should not have a error value.");
-            Assert.True(result.HasValue, "Result should have a Ok value.");
-            Assert.Equal('I', result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.False(result.Either.HasError, "Result should not have a error value.");
+            Assert.True(result.Either.HasValue, "Result should have a Ok value.");
+            Assert.Equal('I', result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
             Assert.Equal("Ok ==> Result<Char, Int32>('I')", result.ToString());
         }
 
@@ -51,10 +51,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         public void Ok_Result_With_String__Expects_String_To_have__Doble_Quotes() {
             var result = "hello".ToMaybe().ToResult(() => 2);
 
-            Assert.False(result.HasError, "Result should not have a error value.");
-            Assert.True(result.HasValue, "Result should have a Ok value.");
-            Assert.Equal("hello", result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.False(result.Either.HasError, "Result should not have a error value.");
+            Assert.True(result.Either.HasValue, "Result should have a Ok value.");
+            Assert.Equal("hello", result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
             Assert.Equal("Ok ==> Result<String, Int32>(\"hello\")", result.ToString());
         }
 
@@ -62,10 +62,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         public void Ok_Result_With_String_Using_Backslash__Expects_String_To_have__Backslash() {
             var result = "hello\\".ToMaybe().ToResult(() => 2);
 
-            Assert.False(result.HasError, "Result should not have a error value.");
-            Assert.True(result.HasValue, "Result should have a Ok value.");
-            Assert.Equal("hello\\", result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.False(result.Either.HasError, "Result should not have a error value.");
+            Assert.True(result.Either.HasValue, "Result should have a Ok value.");
+            Assert.Equal("hello\\", result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
             Assert.Equal("Ok ==> Result<String, Int32>(\"hello\\\")", result.ToString());
         }
 
@@ -73,10 +73,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         public void Ok_Result_With_String_Using_NewLines__Expects_String_To_have__Escaped_Values() {
             var result = "hello\r\nfoo".ToMaybe().ToResult(() => 2);
 
-            Assert.False(result.HasError, "Result should not have a error value.");
-            Assert.True(result.HasValue, "Result should have a Ok value.");
-            Assert.Equal("hello\r\nfoo", result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.False(result.Either.HasError, "Result should not have a error value.");
+            Assert.True(result.Either.HasValue, "Result should have a Ok value.");
+            Assert.Equal("hello\r\nfoo", result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
             Assert.Equal("Ok ==> Result<String, Int32>(\"hello\r\nfoo\")", result.ToString());
         }
 
@@ -84,10 +84,10 @@ namespace Lemonad.ErrorHandling.Test.Result.Tests {
         public void Ok_Result_With_String_Using_Tab__Expects_String_To_have__Escaped_Values() {
             var result = "hello\tfoo".ToMaybe().ToResult(() => 2);
 
-            Assert.False(result.HasError, "Result should not have a error value.");
-            Assert.True(result.HasValue, "Result should have a Ok value.");
-            Assert.Equal("hello\tfoo", result.Value);
-            Assert.Equal(default, result.Error);
+            Assert.False(result.Either.HasError, "Result should not have a error value.");
+            Assert.True(result.Either.HasValue, "Result should have a Ok value.");
+            Assert.Equal("hello\tfoo", result.Either.Value);
+            Assert.Equal(default, result.Either.Error);
             Assert.Equal("Ok ==> Result<String, Int32>(\"hello\tfoo\")", result.ToString());
         }
     }


### PR DESCRIPTION
This lets the consumer handle cases where they know better than what `Result<T, TError>` does.
It also enables makes it easier to create interfaces for `Result<T, TError>` in the future.